### PR TITLE
Fix floating point exception when parsing arguments

### DIFF
--- a/mutilate.cc
+++ b/mutilate.cc
@@ -1056,7 +1056,10 @@ void args_to_options(options_t* options) {
   //  if (args.no_record_scale_given)
   //    options->records = args.records_arg;
   //  else
-  options->records = args.records_arg / options->server_given;
+  if (options->server_given)
+    options->records = args.records_arg / options->server_given;
+  else
+    options->records = 0;
 
   options->binary = args.binary_given;
   options->sasl = args.username_given;


### PR DESCRIPTION
# Problem
Floating point exception occurs when running ```mutilate -T 16 -A``` because no server is passed in.

# Expected Behavior
Client agent mode should not crash.

# Machine Specs
OS: CentOS 7
GCC Version: 4.8.5

# Fix
Calculate # records only if there are servers.